### PR TITLE
Update notes to reflect accurately the assembly code

### DIFF
--- a/asm/script/profiles/profiles.asm
+++ b/asm/script/profiles/profiles.asm
@@ -12,7 +12,7 @@ TextNL equ 0x0A
 TextEnd equ .byte 0x0
 
 .org 0x08CF9E54
-ProfileInfoList:
+ProfileInfoArray:
 	; Captain Falcon
 	.byte 0x00 ; BloodType
 	.byte 0x00 ; Age

--- a/notes.txt
+++ b/notes.txt
@@ -7,11 +7,11 @@ Relevant Offsets
 37CBCC - Font Image Data
 CF7BAC - Story Titles Pointers
 CF9D5C - Story Episodes Pointers
-CF9E58 - Pilot Profiles Pointers
+CF9E54 - Pilot Profiles Pointers
 DCA820 - EoF Padding
 
 ============================================================
-Menu Data Pointers
+Menu Data Pointers - 063608
 ============================================================
 
 Data Structure (8 bytes)
@@ -23,7 +23,7 @@ Data Structure (8 bytes)
   pointer. I haven't looked into it
 
 ============================================================
-Font Image Data
+Font Image Data - 37CBCC
 ============================================================
 
 Character Structure
@@ -38,7 +38,7 @@ Character Structure
   font definition
 
 ============================================================
-Story Titles Pointers
+Story Titles Pointers - CF7BAC
 ============================================================
 
 51 Unsigned Int32's that point to the image data for each
@@ -54,7 +54,7 @@ Image Structure
 * Rows are arranged horizontally for title image
 
 ============================================================
-Story Episodes Pointers
+Story Episodes Pointers - CF9D5C
 ============================================================
 
 51 Unsigned Int32's that point to individual pointer tables
@@ -74,19 +74,20 @@ Diagram:
 * All lines' text data must begin on a 4-byte boundary
 
 ============================================================
-Pilot Profiles Pointers
+Pilot Profiles Pointers - CF9E54
 ============================================================
 
 Data Structure (12 bytes)
+  Blood type           - Byte
+  Age                  - Byte
+  Month of birth       - Byte
+  Day of birth         - Byte
   Pilot Text Pointer   - Unsigned Int32
   Machine Text Pointer - Unsigned Int32
-  Unknown 1            - Unsigned Int32
 
 * 38 structures, one for each pilot, in the order they
   appear on the Pilot Profiles menu; left-to-right,
   top-to-bottom
-* Unknown 1 could be just about anything. I haven't looked
-  into it
 * Pilot and Machine text must begin on a 4-byte boundary
 
 ============================================================


### PR DESCRIPTION
The notes describing the pilote profile structure was out of date.
Changing the `ProfileInfoList` label to `ProfileInfoArray` as it more accurately describes the structure of the code. The different structures are stored contiguously in memory, like an array.